### PR TITLE
회원 가입 및 로그인 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 /src/main/resources/application.yml
 /src/main/resources/application-security.yml
+/src/main/resources/application-jwt.yml

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ out/
 .vscode/
 
 /src/main/resources/application.yml
+/src/main/resources/application-security.yml

--- a/src/main/java/com/parkeunyoung/haksugodae/HaksugodaeApplication.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/HaksugodaeApplication.java
@@ -2,7 +2,9 @@ package com.parkeunyoung.haksugodae;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class HaksugodaeApplication {
 

--- a/src/main/java/com/parkeunyoung/haksugodae/config/SecurityConfig.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/config/SecurityConfig.java
@@ -1,0 +1,45 @@
+package com.parkeunyoung.haksugodae.config;
+
+import com.parkeunyoung.haksugodae.config.oauth.OAuth2FailureHandler;
+import com.parkeunyoung.haksugodae.config.oauth.OAuth2SuccessHandler;
+import com.parkeunyoung.haksugodae.config.oauth.OAuth2UserService;
+import com.parkeunyoung.haksugodae.jwt.filter.JwtTokenFilter;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@AllArgsConstructor
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final OAuth2UserService oAuth2UserService;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final OAuth2FailureHandler oAuth2FailureHandler;
+    private final JwtTokenFilter jwtTokenFilter;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.httpBasic().disable()
+                .csrf().disable()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .authorizeRequests()
+                .anyRequest().permitAll()
+                .and()
+                .addFilterBefore(jwtTokenFilter, UsernamePasswordAuthenticationFilter.class)
+                .oauth2Login()
+                .userInfoEndpoint()
+                .userService(oAuth2UserService)
+                .and()
+                .successHandler(oAuth2SuccessHandler)
+                .failureHandler(oAuth2FailureHandler);
+        return http.build();
+    }
+}

--- a/src/main/java/com/parkeunyoung/haksugodae/config/oauth/OAuth2FailureHandler.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/config/oauth/OAuth2FailureHandler.java
@@ -1,0 +1,22 @@
+package com.parkeunyoung.haksugodae.config.oauth;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Component
+public class OAuth2FailureHandler implements AuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        response.sendRedirect("/oauth2Fail");
+    }
+}

--- a/src/main/java/com/parkeunyoung/haksugodae/config/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/config/oauth/OAuth2SuccessHandler.java
@@ -1,0 +1,32 @@
+package com.parkeunyoung.haksugodae.config.oauth;
+
+import com.parkeunyoung.haksugodae.jwt.util.JwtTokenUtil;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    @Value("${jwt.secretKey}")
+    private String secretKey;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+
+        String name = (String) oAuth2User.getAttributes().get("name");
+        String token = JwtTokenUtil.createToken(name, secretKey, 36000000);
+
+        System.out.println("token : " + token);
+
+        response.addHeader("Authorization", "Bearer " + token);
+    }
+}

--- a/src/main/java/com/parkeunyoung/haksugodae/config/oauth/OAuth2UserService.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/config/oauth/OAuth2UserService.java
@@ -1,0 +1,58 @@
+package com.parkeunyoung.haksugodae.config.oauth;
+
+
+import com.parkeunyoung.haksugodae.config.oauth.provider.KakaoUserInfo;
+import com.parkeunyoung.haksugodae.config.oauth.provider.OAuth2UserInfo;
+import com.parkeunyoung.haksugodae.domain.member.Member;
+import com.parkeunyoung.haksugodae.domain.member.MemberRepository;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Optional;
+
+@AllArgsConstructor
+@Service
+public class OAuth2UserService extends DefaultOAuth2UserService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        OAuth2UserInfo oAuth2UserInfo = null;
+
+        if (userRequest.getClientRegistration().getRegistrationId().equals("kakao")) {
+            oAuth2UserInfo = new KakaoUserInfo(oAuth2User.getAttributes());
+        }
+
+        String provider = oAuth2UserInfo.getProvider();
+        String providerId = oAuth2UserInfo.getProviderId();
+        String name = provider + "_" + providerId;
+        Optional<Member> user = memberRepository.findByName(name);
+
+        HashMap<String, Object> nameMap = new HashMap<>();
+        nameMap.put("name", name);
+
+        if (!user.isPresent()) {
+            memberRepository.save(
+                    Member.builder()
+                            .name(name)
+                            .build()
+            );
+        }
+
+        return new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
+                nameMap, "name"
+        );
+    }
+}

--- a/src/main/java/com/parkeunyoung/haksugodae/config/oauth/provider/KakaoUserInfo.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/config/oauth/provider/KakaoUserInfo.java
@@ -1,0 +1,28 @@
+package com.parkeunyoung.haksugodae.config.oauth.provider;
+
+import java.util.Map;
+
+public class KakaoUserInfo implements OAuth2UserInfo {
+
+    private Map<String, Object> attributes;
+    private Map<String, Object> kakaoAccountAttributes;
+
+    public KakaoUserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+        this.kakaoAccountAttributes = (Map<String, Object>) attributes.get("kakao_account");
+    }
+    @Override
+    public String getProviderId() {
+        return attributes.get("id").toString();
+    }
+
+    @Override
+    public String getProvider() {
+        return "kakao";
+    }
+
+    @Override
+    public String getName() {
+        return (String) kakaoAccountAttributes.get("profile_nickname");
+    }
+}

--- a/src/main/java/com/parkeunyoung/haksugodae/config/oauth/provider/OAuth2UserInfo.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/config/oauth/provider/OAuth2UserInfo.java
@@ -1,0 +1,8 @@
+package com.parkeunyoung.haksugodae.config.oauth.provider;
+
+public interface OAuth2UserInfo {
+
+    String getProviderId();
+    String getProvider();
+    String getName();
+}

--- a/src/main/java/com/parkeunyoung/haksugodae/domain/basetime/BaseTimeEntity.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/domain/basetime/BaseTimeEntity.java
@@ -1,0 +1,23 @@
+package com.parkeunyoung.haksugodae.domain.basetime;
+
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+}

--- a/src/main/java/com/parkeunyoung/haksugodae/domain/member/Member.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/domain/member/Member.java
@@ -23,4 +23,8 @@ public class Member extends BaseTimeEntity {
     private Long memberId;
     private String name;
     private String nickname;
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/parkeunyoung/haksugodae/domain/member/Member.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/domain/member/Member.java
@@ -6,8 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.hibernate.annotations.Entity;
 
+import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;

--- a/src/main/java/com/parkeunyoung/haksugodae/domain/member/Member.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/domain/member/Member.java
@@ -1,0 +1,26 @@
+package com.parkeunyoung.haksugodae.domain.member;
+
+
+import com.parkeunyoung.haksugodae.domain.basetime.BaseTimeEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.annotations.Entity;
+
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+@Getter
+@Builder
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class Member extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long memberId;
+    private String name;
+    private String nickname;
+}

--- a/src/main/java/com/parkeunyoung/haksugodae/domain/member/MemberRepository.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/domain/member/MemberRepository.java
@@ -2,6 +2,9 @@ package com.parkeunyoung.haksugodae.domain.member;
 
 import org.springframework.data.repository.Repository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends Repository<Member, Long> {
     void save(Member member);
+    Optional<Member> findByName(String name);
 }

--- a/src/main/java/com/parkeunyoung/haksugodae/domain/member/MemberRepository.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/domain/member/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.parkeunyoung.haksugodae.domain.member;
+
+import org.springframework.data.repository.Repository;
+
+public interface MemberRepository extends Repository<Member, Long> {
+    void save(Member member);
+}

--- a/src/main/java/com/parkeunyoung/haksugodae/jwt/filter/JwtTokenFilter.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/jwt/filter/JwtTokenFilter.java
@@ -1,0 +1,67 @@
+package com.parkeunyoung.haksugodae.jwt.filter;
+
+
+import com.parkeunyoung.haksugodae.domain.member.Member;
+import com.parkeunyoung.haksugodae.jwt.util.JwtTokenUtil;
+import com.parkeunyoung.haksugodae.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+
+@RequiredArgsConstructor
+@Component
+public class JwtTokenFilter extends OncePerRequestFilter {
+
+    @Value("${jwt.secretKey}")
+    private String secretKey;
+    private final MemberService memberService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (header == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if (!header.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = header.split(" ")[1];
+
+        if (JwtTokenUtil.isExpired(token, secretKey)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String name = JwtTokenUtil.getName(token, secretKey);
+        Member user = memberService.getMemberByName(name);
+
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+                user.getName(), null, Arrays.asList(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+
+        authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+        filterChain.doFilter(request, response);
+
+
+    }
+}

--- a/src/main/java/com/parkeunyoung/haksugodae/jwt/util/JwtTokenUtil.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/jwt/util/JwtTokenUtil.java
@@ -1,0 +1,35 @@
+package com.parkeunyoung.haksugodae.jwt.util;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+
+import java.util.Date;
+
+public class JwtTokenUtil {
+
+    public static String createToken(String name, String key, long expiredTimeMs) {
+        Claims claims = Jwts.claims();
+        claims.put("name", name);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + expiredTimeMs))
+                .signWith(SignatureAlgorithm.HS256, key)
+                .compact();
+    }
+
+    public static String getName(String token, String secretKey) {
+        return extractClaims(token, secretKey).get("name").toString();
+    }
+
+    public static boolean isExpired(String token, String secretKey) {
+        Date expiration = extractClaims(token, secretKey).getExpiration();
+        return expiration.before(new Date());
+    }
+
+    public static Claims extractClaims(String token, String secretKey) {
+        return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
+    }
+}

--- a/src/main/java/com/parkeunyoung/haksugodae/service/MemberService.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/service/MemberService.java
@@ -1,0 +1,17 @@
+package com.parkeunyoung.haksugodae.service;
+
+import com.parkeunyoung.haksugodae.domain.member.MemberRepository;
+import com.parkeunyoung.haksugodae.web.dto.MemberRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public String register(MemberRequestDto memberRequestDto, String username) {
+        return "변경";
+    }
+}

--- a/src/main/java/com/parkeunyoung/haksugodae/service/MemberService.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/service/MemberService.java
@@ -1,9 +1,12 @@
 package com.parkeunyoung.haksugodae.service;
 
+import com.parkeunyoung.haksugodae.domain.member.Member;
 import com.parkeunyoung.haksugodae.domain.member.MemberRepository;
 import com.parkeunyoung.haksugodae.web.dto.MemberRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -11,7 +14,16 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
 
-    public String register(MemberRequestDto memberRequestDto, String username) {
+    @Transactional
+    public String register(MemberRequestDto memberRequestDto, String name) {
+        Member member = memberRepository.findByName(name)
+                .orElseThrow(() -> new IllegalArgumentException("해당 멤버가 없습니다."));
+        member.updateNickname(memberRequestDto.getNickname());
         return "변경";
+    }
+
+    public Member getMemberByName(String name) {
+        return memberRepository.findByName(name)
+                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 없습니다."));
     }
 }

--- a/src/main/java/com/parkeunyoung/haksugodae/web/controller/MemberController.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/web/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.parkeunyoung.haksugodae.web.dto.MemberRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -14,7 +15,7 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("/register")
-    public String register(MemberRequestDto memberRequestDto, Authentication auth) {
+    public String register(@RequestBody MemberRequestDto memberRequestDto, Authentication auth) {
         return memberService.register(memberRequestDto, auth.getName());
     }
 }

--- a/src/main/java/com/parkeunyoung/haksugodae/web/controller/MemberController.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/web/controller/MemberController.java
@@ -1,0 +1,20 @@
+package com.parkeunyoung.haksugodae.web.controller;
+
+import com.parkeunyoung.haksugodae.service.MemberService;
+import com.parkeunyoung.haksugodae.web.dto.MemberRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/register")
+    public String register(MemberRequestDto memberRequestDto, Authentication auth) {
+        return memberService.register(memberRequestDto, auth.getName());
+    }
+}

--- a/src/main/java/com/parkeunyoung/haksugodae/web/dto/MemberRequestDto.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/web/dto/MemberRequestDto.java
@@ -1,0 +1,16 @@
+package com.parkeunyoung.haksugodae.web.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberRequestDto {
+
+    private String nickname;
+}


### PR DESCRIPTION
## 관련 이슈

- #1 

## TO-BE

- 카카오 로그인 진행 시 강제 회원 가입을 진행하고 회원 가입을 한 회원이면 로그인을 진행하여 jwt 토큰을 반환함
- config
	- oauth service, handler, provider 구현
- jwt
	- filter, util : 토큰 생성 및 토큰이 만료되지 않았는지, 토큰의 형태인지 확인
