### PR TITLE
유리병 생성 삭제 기능 구현

### DIFF
--- a/src/main/java/com/parkeunyoung/haksugodae/domain/bottle/Bottle.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/domain/bottle/Bottle.java
@@ -1,0 +1,32 @@
+package com.parkeunyoung.haksugodae.domain.bottle;
+
+
+import com.parkeunyoung.haksugodae.domain.basetime.BaseTimeEntity;
+import com.parkeunyoung.haksugodae.domain.member.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.Date;
+
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class Bottle extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long bottleId;
+    private String title;
+    private Date dDay;
+    private String bottleDesign;
+    private String bottleColor;
+    private Boolean showOrNot;
+    private Long paperCraneCnt;
+    @ManyToOne
+    private Member member;
+}

--- a/src/main/java/com/parkeunyoung/haksugodae/domain/bottle/BottleRepository.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/domain/bottle/BottleRepository.java
@@ -4,9 +4,11 @@ import com.parkeunyoung.haksugodae.domain.member.Member;
 import org.springframework.data.repository.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface BottleRepository extends Repository<Bottle, Long> {
     void save(Bottle bottle);
     List<Bottle> findByMember(Member member);
     void delete(Bottle bottle);
+    Optional<Bottle> findById(Long bottleId);
 }

--- a/src/main/java/com/parkeunyoung/haksugodae/domain/bottle/BottleRepository.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/domain/bottle/BottleRepository.java
@@ -1,0 +1,11 @@
+package com.parkeunyoung.haksugodae.domain.bottle;
+
+import com.parkeunyoung.haksugodae.domain.member.Member;
+import org.springframework.data.repository.Repository;
+
+import java.util.Optional;
+
+public interface BottleRepository extends Repository<Bottle, Long> {
+    void save(Member member);
+    Optional<Member> findByMember(Member member);
+}

--- a/src/main/java/com/parkeunyoung/haksugodae/domain/bottle/BottleRepository.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/domain/bottle/BottleRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface BottleRepository extends Repository<Bottle, Long> {
     void save(Bottle bottle);
     List<Bottle> findByMember(Member member);
+    void delete(Bottle bottle);
 }

--- a/src/main/java/com/parkeunyoung/haksugodae/domain/bottle/BottleRepository.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/domain/bottle/BottleRepository.java
@@ -3,9 +3,9 @@ package com.parkeunyoung.haksugodae.domain.bottle;
 import com.parkeunyoung.haksugodae.domain.member.Member;
 import org.springframework.data.repository.Repository;
 
-import java.util.Optional;
+import java.util.List;
 
 public interface BottleRepository extends Repository<Bottle, Long> {
-    void save(Member member);
-    Optional<Member> findByMember(Member member);
+    void save(Bottle bottle);
+    List<Bottle> findByMember(Member member);
 }

--- a/src/main/java/com/parkeunyoung/haksugodae/service/BottleService.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/service/BottleService.java
@@ -9,6 +9,7 @@ import com.parkeunyoung.haksugodae.web.dto.BottleDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -28,6 +29,7 @@ public class BottleService {
                 .bottleColor(detail.getBottleColor())
                 .bottleDesign(detail.getBottleDesign())
                 .showOrNot(detail.getShowOrNot())
+                .paperCraneCnt(0L)
                 .member(member)
                 .build());
 
@@ -47,12 +49,12 @@ public class BottleService {
         return "본인의 것이 아닙니다";
     }
 
-    public BottleDto.SummaryList showBottleMyMember(String name) {
+    public List<BottleDto.Summary> showBottleMyMember(String name) {
         Member member = memberRepository.findByName(name)
                 .orElseThrow(IllegalArgumentException::new);
         List<Bottle> bottles = bottleRepository.findByMember(member);
 
-        BottleDto.SummaryList.SummaryListBuilder listBuilder = BottleDto.SummaryList.builder();
+        List<BottleDto.Summary> summaries = new ArrayList<>();
 
         for (Bottle bottle : bottles) {
             BottleDto.Summary summary = BottleDto.Summary.builder()
@@ -61,8 +63,27 @@ public class BottleService {
                     .bottleColor(bottle.getBottleColor())
                     .bottleDesign(bottle.getBottleDesign())
                     .build();
-            listBuilder.bottles(Collections.singletonList(summary));
+            summaries.add(summary);
         }
-        return listBuilder.build();
+        return summaries;
+    }
+
+    public BottleDto.Detail showBottle(Long bottleId) {
+        Bottle bottle = bottleRepository.findById(bottleId)
+                .orElseThrow(IllegalArgumentException::new);
+
+        BottleDto.Detail.DetailBuilder builder = BottleDto.Detail.builder()
+                .title(bottle.getTitle())
+                .dDay(bottle.getDDay())
+                .bottleDesign(bottle.getBottleDesign())
+                .bottleColor(bottle.getBottleColor())
+                .showOrNot(bottle.getShowOrNot());
+
+        if (bottle.getShowOrNot()) {
+            return builder.paperCraneCnt(bottle.getPaperCraneCnt()).build();
+        } else {
+            return builder.paperCraneCnt(null).build();
+        }
+
     }
 }

--- a/src/main/java/com/parkeunyoung/haksugodae/service/BottleService.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/service/BottleService.java
@@ -1,0 +1,68 @@
+package com.parkeunyoung.haksugodae.service;
+
+
+import com.parkeunyoung.haksugodae.domain.bottle.Bottle;
+import com.parkeunyoung.haksugodae.domain.bottle.BottleRepository;
+import com.parkeunyoung.haksugodae.domain.member.Member;
+import com.parkeunyoung.haksugodae.domain.member.MemberRepository;
+import com.parkeunyoung.haksugodae.web.dto.BottleDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BottleService {
+
+    private final BottleRepository bottleRepository;
+    private final MemberRepository memberRepository;
+
+    public String makeBottle(BottleDto.Detail detail, String name) {
+        Member member = memberRepository.findByName(name)
+                .orElseThrow(IllegalArgumentException::new);
+        bottleRepository.save(Bottle.builder()
+                .title(detail.getTitle())
+                .dDay(detail.getDDay())
+                .bottleColor(detail.getBottleColor())
+                .bottleDesign(detail.getBottleDesign())
+                .showOrNot(detail.getShowOrNot())
+                .member(member)
+                .build());
+
+        return "생성";
+    }
+
+    public String deleteBottle(BottleDto.Id id, String name) {
+        Member member = memberRepository.findByName(name)
+                .orElseThrow(IllegalArgumentException::new);
+        List<Bottle> bottles = bottleRepository.findByMember(member);
+        for (Bottle bottle : bottles) {
+            if (bottle.getBottleId() == id.getBottleId()) {
+                bottleRepository.delete(bottle);
+                return "삭제";
+            }
+        }
+        return "본인의 것이 아닙니다";
+    }
+
+    public BottleDto.SummaryList showBottleMyMember(String name) {
+        Member member = memberRepository.findByName(name)
+                .orElseThrow(IllegalArgumentException::new);
+        List<Bottle> bottles = bottleRepository.findByMember(member);
+
+        BottleDto.SummaryList.SummaryListBuilder listBuilder = BottleDto.SummaryList.builder();
+
+        for (Bottle bottle : bottles) {
+            BottleDto.Summary summary = BottleDto.Summary.builder()
+                    .bottleId(bottle.getBottleId())
+                    .title(bottle.getTitle())
+                    .bottleColor(bottle.getBottleColor())
+                    .bottleDesign(bottle.getBottleDesign())
+                    .build();
+            listBuilder.bottles(Collections.singletonList(summary));
+        }
+        return listBuilder.build();
+    }
+}

--- a/src/main/java/com/parkeunyoung/haksugodae/web/controller/BottleController.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/web/controller/BottleController.java
@@ -6,6 +6,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 public class BottleController {
@@ -32,8 +34,19 @@ public class BottleController {
         본인 유리병의 일부 정보 반환
      */
     @GetMapping("/bottle")
-    public BottleDto.SummaryList showBottleByMember(Authentication auth) {
+    public List<BottleDto.Summary> showBottleByMember(Authentication auth) {
         return bottleService.showBottleMyMember(auth.getName());
+    }
+
+    /*
+        하나의 유리병에 대한 정보 반환
+        - showOrNot 이 true 이면 paperCraneCnt 정수값
+        - showOrNot 이 false 이면 paperCraneCnt null
+
+     */
+    @GetMapping("/bottle/{bottleId}")
+    public BottleDto.Detail showBottle(@PathVariable Long bottleId) {
+        return bottleService.showBottle(bottleId);
     }
 
 }

--- a/src/main/java/com/parkeunyoung/haksugodae/web/controller/BottleController.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/web/controller/BottleController.java
@@ -1,0 +1,39 @@
+package com.parkeunyoung.haksugodae.web.controller;
+
+import com.parkeunyoung.haksugodae.service.BottleService;
+import com.parkeunyoung.haksugodae.web.dto.BottleDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class BottleController {
+
+    private final BottleService bottleService;
+
+    /*
+        유리병 생성
+     */
+    @PostMapping("/bottle")
+    public String makeBottle(@RequestBody BottleDto.Detail detail, Authentication auth) {
+        return bottleService.makeBottle(detail, auth.getName());
+    }
+
+    /*
+        유리병 삭제
+     */
+    @DeleteMapping("/bottle")
+    public String deleteBottle(@RequestBody BottleDto.Id id, Authentication auth) {
+        return bottleService.deleteBottle(id, auth.getName());
+    }
+
+    /*
+        본인 유리병의 일부 정보 반환
+     */
+    @GetMapping("/bottle")
+    public BottleDto.SummaryList showBottleByMember(Authentication auth) {
+        return bottleService.showBottleMyMember(auth.getName());
+    }
+
+}

--- a/src/main/java/com/parkeunyoung/haksugodae/web/dto/BottleDto.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/web/dto/BottleDto.java
@@ -1,0 +1,53 @@
+package com.parkeunyoung.haksugodae.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.*;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.util.Date;
+import java.util.List;
+
+
+public class BottleDto {
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    @ToString
+    public static class Detail {
+        private String title;
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        private Date dDay;
+        private String bottleDesign;
+        private String bottleColor;
+        private Boolean showOrNot;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class Id {
+        private Long bottleId;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class Summary {
+        private Long bottleId;
+        private String title;
+        private String bottleDesign;
+        private String bottleColor;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class SummaryList {
+        private List<Summary> bottles;
+    }
+}

--- a/src/main/java/com/parkeunyoung/haksugodae/web/dto/BottleDto.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/web/dto/BottleDto.java
@@ -22,6 +22,7 @@ public class BottleDto {
         private String bottleDesign;
         private String bottleColor;
         private Boolean showOrNot;
+        private Long paperCraneCnt;
     }
 
     @Getter
@@ -41,13 +42,5 @@ public class BottleDto {
         private String title;
         private String bottleDesign;
         private String bottleColor;
-    }
-
-    @Getter
-    @AllArgsConstructor
-    @NoArgsConstructor
-    @Builder
-    public static class SummaryList {
-        private List<Summary> bottles;
     }
 }


### PR DESCRIPTION
## 관련 이슈

- #3

## TO-BE

- 사용자가 유리병을 생성하고 본인의 유리병을 삭제할 수 있음 (여러 개 생성 가능)
- 로그인 하지 않은 사용자는 bottleId 를 알고 있으면 하나의 유리병 정보를 받을 수 있음
- 로그인 한 사용자는 본인 유리병들의 정보를 받을 수 있음
- showOrNot 에 따라 paperCraneCnt의 값이 null 또는 Long 타입이 됨
- domain/bottle
	- 유리병 엔티티와 레포지토리
- service/BottleService
	- 유리병 생성, 삭제, 정보 반환 서비스
- controller/BottleController
	- 유리병 컨트롤러
- dto/BottleDto
	- 유리병 관련 dto들을 inner class로 관리함