### PR TITLE
종이학 생성, 정보 반환 기능 구현

### DIFF
--- a/src/main/java/com/parkeunyoung/haksugodae/domain/crane/Crane.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/domain/crane/Crane.java
@@ -14,7 +14,7 @@ import javax.persistence.*;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-class Crane extends BaseTimeEntity {
+public class Crane extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long craneId;
@@ -27,5 +27,9 @@ class Crane extends BaseTimeEntity {
 
     @ManyToOne
     private Bottle bottle;
+
+    public void updateView(Boolean view) {
+        this.view = view;
+    }
 
 }

--- a/src/main/java/com/parkeunyoung/haksugodae/domain/crane/Crane.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/domain/crane/Crane.java
@@ -1,0 +1,31 @@
+package com.parkeunyoung.haksugodae.domain.crane;
+
+import com.parkeunyoung.haksugodae.domain.basetime.BaseTimeEntity;
+import com.parkeunyoung.haksugodae.domain.bottle.Bottle;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+class Crane extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long craneId;
+
+    private String title;
+    private String content;
+    private String craneDesign;
+    private String craneColor;
+    private Boolean view;
+
+    @ManyToOne
+    private Bottle bottle;
+
+}

--- a/src/main/java/com/parkeunyoung/haksugodae/domain/crane/CraneRepository.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/domain/crane/CraneRepository.java
@@ -1,0 +1,6 @@
+package com.parkeunyoung.haksugodae.domain.crane;
+
+import org.springframework.data.repository.Repository;
+
+public interface CraneRepository extends Repository<Crane, Long> {
+}

--- a/src/main/java/com/parkeunyoung/haksugodae/domain/crane/CraneRepository.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/domain/crane/CraneRepository.java
@@ -1,6 +1,11 @@
 package com.parkeunyoung.haksugodae.domain.crane;
 
+import com.parkeunyoung.haksugodae.domain.bottle.Bottle;
 import org.springframework.data.repository.Repository;
 
+import java.util.List;
+
 public interface CraneRepository extends Repository<Crane, Long> {
+    void save(Crane crane);
+    List<Crane> findByBottle(Bottle bottle);
 }

--- a/src/main/java/com/parkeunyoung/haksugodae/service/CraneService.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/service/CraneService.java
@@ -1,0 +1,95 @@
+package com.parkeunyoung.haksugodae.service;
+
+import com.parkeunyoung.haksugodae.domain.bottle.Bottle;
+import com.parkeunyoung.haksugodae.domain.bottle.BottleRepository;
+import com.parkeunyoung.haksugodae.domain.crane.Crane;
+import com.parkeunyoung.haksugodae.domain.crane.CraneRepository;
+import com.parkeunyoung.haksugodae.domain.member.Member;
+import com.parkeunyoung.haksugodae.domain.member.MemberRepository;
+import com.parkeunyoung.haksugodae.web.dto.CraneDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CraneService {
+
+    private final CraneRepository craneRepository;
+    private final BottleRepository bottleRepository;
+    private final MemberRepository memberRepository;
+
+    public String makeCrane(CraneDto.Detail detail) {
+        Bottle bottle = bottleRepository.findById(detail.getBottleId())
+                .orElseThrow(IllegalArgumentException::new);
+        craneRepository.save(
+                Crane.builder()
+                        .title(detail.getTitle())
+                        .content(detail.getContent())
+                        .craneDesign(detail.getCraneDesign())
+                        .craneColor(detail.getCraneColor())
+                        .view(false)
+                        .bottle(bottle)
+                        .build()
+        );
+        return "생성";
+    }
+
+    public List<CraneDto.Summary> showCraneByAnyone(CraneDto.Id id) {
+        Bottle bottle = bottleRepository.findById(id.getBottleId())
+                .orElseThrow(IllegalArgumentException::new);
+        List<Crane> cranes = craneRepository.findByBottle(bottle);
+
+        List<CraneDto.Summary> summaries = new ArrayList<>();
+
+        for (Crane crane : cranes) {
+            summaries.add(
+                    CraneDto.Summary.builder()
+                            .craneId(crane.getCraneId())
+                            .title(crane.getTitle())
+                            .view(crane.getView())
+                            .build()
+            );
+        }
+
+        return summaries;
+    }
+    @Transactional
+    public List<CraneDto.Detail> showCraneByOwner(Long bottleId, String name) {
+        Member member = memberRepository.findByName(name)
+                .orElseThrow(IllegalArgumentException::new);
+
+        // 요청 받은 유리병
+        Bottle requestBottle = bottleRepository.findById(bottleId)
+                .orElseThrow(IllegalArgumentException::new);
+
+        // 본인의 유리병 리스트
+        List<Bottle> bottles = bottleRepository.findByMember(member);
+
+        List<CraneDto.Detail> details = new ArrayList<>();
+
+        for (Bottle bottle : bottles) {
+            if (bottle.getBottleId() == requestBottle.getBottleId()) {
+                List<Crane> cranes = craneRepository.findByBottle(requestBottle);
+
+                for (Crane crane : cranes) {
+                    details.add(
+                            CraneDto.Detail.builder()
+                                    .title(crane.getTitle())
+                                    .content(crane.getContent())
+                                    .craneDesign(crane.getCraneDesign())
+                                    .craneColor(crane.getCraneColor())
+                                    .bottleId(bottleId)
+                                    .build()
+                    );
+                    crane.updateView(true);
+                }
+                return details;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/parkeunyoung/haksugodae/web/controller/CraneController.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/web/controller/CraneController.java
@@ -1,0 +1,40 @@
+package com.parkeunyoung.haksugodae.web.controller;
+
+import com.parkeunyoung.haksugodae.service.CraneService;
+import com.parkeunyoung.haksugodae.web.dto.CraneDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class CraneController {
+
+    private final CraneService craneService;
+
+    /*
+        종이학 생성
+     */
+    @PostMapping("/crane")
+    public String makeCrane(@RequestBody CraneDto.Detail detail) {
+        return craneService.makeCrane(detail);
+    }
+
+    /*
+        누구나 종이학 제목과 디자인, craneId 에 대해 반환
+     */
+    @GetMapping("/crane")
+    public List<CraneDto.Summary> showCraneByAnyone(@RequestBody CraneDto.Id id) {
+        return craneService.showCraneByAnyone(id);
+    }
+
+    /*
+        본인의 유리병 일 경우 종이학 내용을 반환
+     */
+    @GetMapping("/crane/{bottleId}")
+    public List<CraneDto.Detail> showCraneByOwner(@PathVariable Long bottleId, Authentication auth) {
+        return craneService.showCraneByOwner(bottleId, auth.getName());
+    }
+}

--- a/src/main/java/com/parkeunyoung/haksugodae/web/dto/CraneDto.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/web/dto/CraneDto.java
@@ -1,0 +1,40 @@
+package com.parkeunyoung.haksugodae.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class CraneDto {
+
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class Detail {
+        private String title;
+        private String content;
+        private String craneDesign;
+        private String craneColor;
+        private Long bottleId;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class Id {
+        private Long bottleId;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class Summary {
+        private Long craneId;
+        private String title;
+        private Boolean view;
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- #5 

## TO-BE

- 종이학은 로그인 하지 않은 사용자도 생성할 수 있음 (여러 개 가능)
- 로그인 하지 않은 사용자 또한 종이학의 일부 정보를 받을 수 있음 (종이학 제목 등)
- 로그인한 사용자 중 본인의 유리병일 경우 종이학의 내용을 받을 수 있음
- 본인이 아닐 경우 null 값 반환
- 본인이 종이학의 내용을 확인했을 경우 view의 값은 true 로 변경됨
- domain/crane
	- 종이학 엔티티와 레포지토리
- service/CraneService
	- 종이학 생성, 정보 반환 서비스
- controller/CraneController
	- 종이학 컨트롤러
- dto/CraneDto
	- 종이학 관련 dto들을 inner class 로 관리