### PR TITLE
Feat: 새로 생성된 종이학 알림을 위한 기능 추가

### DIFF
--- a/src/main/java/com/parkeunyoung/haksugodae/domain/bottle/Bottle.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/domain/bottle/Bottle.java
@@ -27,6 +27,13 @@ public class Bottle extends BaseTimeEntity {
     private String bottleColor;
     private Boolean showOrNot;
     private Long paperCraneCnt;
+    private Boolean view;
     @ManyToOne
     private Member member;
+    public void updateView(Boolean view) {
+        this.view = view;
+    }
+    public void increaseCraneCnt() {
+        this.paperCraneCnt++;
+    }
 }

--- a/src/main/java/com/parkeunyoung/haksugodae/domain/crane/Crane.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/domain/crane/Crane.java
@@ -23,13 +23,6 @@ public class Crane extends BaseTimeEntity {
     private String content;
     private String craneDesign;
     private String craneColor;
-    private Boolean view;
-
     @ManyToOne
     private Bottle bottle;
-
-    public void updateView(Boolean view) {
-        this.view = view;
-    }
-
 }

--- a/src/main/java/com/parkeunyoung/haksugodae/service/BottleService.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/service/BottleService.java
@@ -10,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -30,6 +29,7 @@ public class BottleService {
                 .bottleDesign(detail.getBottleDesign())
                 .showOrNot(detail.getShowOrNot())
                 .paperCraneCnt(0L)
+                .view(false)
                 .member(member)
                 .build());
 
@@ -62,6 +62,7 @@ public class BottleService {
                     .title(bottle.getTitle())
                     .bottleColor(bottle.getBottleColor())
                     .bottleDesign(bottle.getBottleDesign())
+                    .view(bottle.getView())
                     .build();
             summaries.add(summary);
         }
@@ -77,7 +78,8 @@ public class BottleService {
                 .dDay(bottle.getDDay())
                 .bottleDesign(bottle.getBottleDesign())
                 .bottleColor(bottle.getBottleColor())
-                .showOrNot(bottle.getShowOrNot());
+                .showOrNot(bottle.getShowOrNot())
+                .view(bottle.getView());
 
         if (bottle.getShowOrNot()) {
             return builder.paperCraneCnt(bottle.getPaperCraneCnt()).build();

--- a/src/main/java/com/parkeunyoung/haksugodae/service/CraneService.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/service/CraneService.java
@@ -22,6 +22,7 @@ public class CraneService {
     private final BottleRepository bottleRepository;
     private final MemberRepository memberRepository;
 
+    @Transactional
     public String makeCrane(CraneDto.Detail detail) {
         Bottle bottle = bottleRepository.findById(detail.getBottleId())
                 .orElseThrow(IllegalArgumentException::new);
@@ -31,10 +32,11 @@ public class CraneService {
                         .content(detail.getContent())
                         .craneDesign(detail.getCraneDesign())
                         .craneColor(detail.getCraneColor())
-                        .view(false)
                         .bottle(bottle)
                         .build()
         );
+        bottle.increaseCraneCnt();
+        bottle.updateView(true);
         return "생성";
     }
 
@@ -50,7 +52,6 @@ public class CraneService {
                     CraneDto.Summary.builder()
                             .craneId(crane.getCraneId())
                             .title(crane.getTitle())
-                            .view(crane.getView())
                             .build()
             );
         }
@@ -85,8 +86,8 @@ public class CraneService {
                                     .bottleId(bottleId)
                                     .build()
                     );
-                    crane.updateView(true);
                 }
+                bottle.updateView(false);
                 return details;
             }
         }

--- a/src/main/java/com/parkeunyoung/haksugodae/web/dto/BottleDto.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/web/dto/BottleDto.java
@@ -23,6 +23,7 @@ public class BottleDto {
         private String bottleColor;
         private Boolean showOrNot;
         private Long paperCraneCnt;
+        private Boolean view;
     }
 
     @Getter
@@ -42,5 +43,6 @@ public class BottleDto {
         private String title;
         private String bottleDesign;
         private String bottleColor;
+        private Boolean view;
     }
 }

--- a/src/main/java/com/parkeunyoung/haksugodae/web/dto/CraneDto.java
+++ b/src/main/java/com/parkeunyoung/haksugodae/web/dto/CraneDto.java
@@ -35,6 +35,5 @@ public class CraneDto {
     public static class Summary {
         private Long craneId;
         private String title;
-        private Boolean view;
     }
 }


### PR DESCRIPTION
## 관련 이슈

- #7 

## TO-BE

- 종이학이 생성되면 종이학이 생성된 유리병의 view를 true 로 변경
- 종이학이 /crane/{boradId} 로 주인에게 읽히면 유리병의 view를 false로 변경
- 종이학 생성 시, 유리병의 paperCraneCnt의 값을 증가시킴 
- domain/bottle
	- view 컬럼을 추가함
	- updateView 메서드와 increaseCraneCnt 메서드를 추가함
- domain/crane
	- view 컬럼을 삭제함 (기존 api의 오류)
- service/CraneService
	- makeCrane 메서드를 위와 같이 수정